### PR TITLE
Allow manual override of max temp via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ services:
       - IDRAC_USER=root # set to your IPMI username
       - IDRAC_PW=calvin # set to your IPMI password
       - FANSPEED=0x05 # set to the hex value you want to set the fans to (from 0 to 100)
+      - MAXTEMP=32 # set the maximum temperature (in celcius) before dynamic fan control kicks back in, optional, defaults to 32
 ```

--- a/check-temp.sh
+++ b/check-temp.sh
@@ -2,8 +2,7 @@ IPMIHOST=`cat /host.txt`
 IPMIUSER=`cat /user.txt`
 IPMIPW=`cat /pw.txt`
 FANSPEED=`cat /fanspeed.txt`
-
-MAXTEMP=${MAXTEMP:-32}
+MAXTEMP=`cat /maxtemp.txt`
 
 TEMP=$(ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW sdr type temperature |grep Inlet |grep degrees |grep -Po '\d{2}' | tail -1)
 

--- a/check-temp.sh
+++ b/check-temp.sh
@@ -3,7 +3,7 @@ IPMIUSER=`cat /user.txt`
 IPMIPW=`cat /pw.txt`
 FANSPEED=`cat /fanspeed.txt`
 
-MAXTEMP=32
+MAXTEMP=${MAXTEMP:-32}
 
 TEMP=$(ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW sdr type temperature |grep Inlet |grep degrees |grep -Po '\d{2}' | tail -1)
 

--- a/startup.sh
+++ b/startup.sh
@@ -2,8 +2,10 @@ echo $IDRAC_HOST >> /host.txt
 echo $IDRAC_USER >> /user.txt
 echo $IDRAC_PW >> /pw.txt
 echo $FANSPEED >> /fanspeed.txt
+echo ${MAXTEMP:-32} >> /maxtemp.txt
 
 echo "Host: `cat /host.txt`"
 echo "User: `cat /user.txt`"
 echo "PW: `cat /pw.txt`"
 echo "Fan speed `cat /fanspeed.txt`"
+echo "Max temp: `cat /maxtemp.txt`"


### PR DESCRIPTION
This change allows `MAXTEMP` to be specified as a docker environment variable.